### PR TITLE
Update modules source repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ VMware Workstation uses kernel modules to work, but their official releases don'
 
 This script installs modified kernel modules and a service to automatically build them at boot for every kernel update, offering a more seamless experience.
 
-The current version of this software is made for Fedora 42 and VMware Workstation 17.6.
+The current version of this software is made for Fedora 43 and VMware Workstation 25H2.
 This software is provided *as-is*, proceed at your own risk.
 If you wish, [read the source](https://github.com/jhenriquelc/fedora-vmware-installer/blob/main/install.sh) to see what it does before you run it.
 
-Currently using [modified kernel modules from Bytium](https://github.com/bytium/vm-host-modules).
+Currently using [modified kernel modules from philipl](https://github.com/philipl/vmware-host-modules/tree/workstation-25h2).
 
 ## Secure Boot
 

--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,7 @@ if [[ -e vm-host-modules ]]; then
 fi
 
 echo "Cloning modified kernel modules source code..."
-git clone -b 17.6 https://github.com/bytium/vm-host-modules
+git clone -b workstation-25h2 https://github.com/philipl/vmware-host-modules vm-host-modules
 cd vm-host-modules/
 
 echo "Building..."


### PR DESCRIPTION
Updates the modules source repo for the newest Kernel in Fedora 43 for VMWare Workstation 25H2.

Used this one line change as an excuse to try out Copilot Agent Mode, probably won't use this again lol.

Fixes #3 

Agent-Logs-Url: https://github.com/jhenriquelc/fedora-vmware-installer/sessions/c0eefb7c-acb2-426c-91a5-653801cd4dd1